### PR TITLE
Feature/chat df schema

### DIFF
--- a/whatstk/analysis/base.py
+++ b/whatstk/analysis/base.py
@@ -2,6 +2,7 @@
 
 
 import pandas as pd
+from whatstk.utils.utils import COLNAMES_DF
 
 
 def get_interventions_count(df=None, chat=None, date_mode='date', msg_length=False, cummulative=False):
@@ -65,7 +66,7 @@ def get_interventions_count(df=None, chat=None, date_mode='date', msg_length=Fal
         n_interventions.index = n_interventions.index.set_names(['weekday', 'hour'])
     else:
         n_interventions.index.name = date_mode
-    n_interventions.columns = n_interventions.columns.get_level_values('username')
+    n_interventions.columns = n_interventions.columns.get_level_values(COLNAMES_DF.USERNAME)
 
     if cummulative:
         n_interventions = n_interventions.cumsum()
@@ -85,10 +86,12 @@ def _interventions(df, index_date, msg_length):
     """
     if msg_length:
         counts_ = df.copy()
-        counts_['message_length'] = counts_['message'].apply(lambda x: len(x))
-        counts = counts_.groupby(by=index_date + ['username']).agg({'message_length': lambda x: x.sum()})
+        counts_[COLNAMES_DF.MESSAGE_LENGTH] = counts_[COLNAMES_DF.MESSAGE].apply(lambda x: len(x))
+        counts = counts_.groupby(by=index_date + [COLNAMES_DF.USERNAME]).agg({
+            COLNAMES_DF.MESSAGE_LENGTH: lambda x: x.sum()
+        })
     else:
-        counts = df.groupby(by=index_date + ['username']).agg('count')
+        counts = df.groupby(by=index_date + [COLNAMES_DF.USERNAME]).agg('count')
     counts = counts.unstack(fill_value=0)
 
     return counts

--- a/whatstk/objects.py
+++ b/whatstk/objects.py
@@ -9,6 +9,7 @@ from whatstk.utils.parser import generate_regex, parse_chat, remove_alerts_from_
 from whatstk.utils.auto_header import extract_header_from_text
 from whatstk.utils.exceptions import RegexError, HFormatError
 from whatstk.utils.chat_merge import merge_chats
+from whatstk.utils.utils import COLNAMES_DF
 
 
 class WhatsAppChat:
@@ -17,7 +18,7 @@ class WhatsAppChat:
     def __init__(self, df):
         """Constructor."""
         self.df = df
-        self.users = sorted(self.df.username.unique().tolist())
+        self.users = sorted(list(self.df[COLNAMES_DF.USERNAME].unique()))
         self.start_date = df.index.min()
         self.end_date = df.index.max()
 
@@ -159,7 +160,7 @@ class WhatsAppChat:
             if not isinstance(old_names, list):
                 raise ValueError("New names must come as a list of str.")
             for old_name in old_names:
-                df.username[df['username'] == old_name] = new_name
+                df[COLNAMES_DF.USERNAME][df[COLNAMES_DF.USERNAME] == old_name] = new_name
         return WhatsAppChat(df)
 
     def to_txt(self, filename, hformat=None):

--- a/whatstk/plotly/figures/boxplot.py
+++ b/whatstk/plotly/figures/boxplot.py
@@ -3,6 +3,7 @@
 
 import plotly.graph_objs as go
 import plotly.express as px
+from whatstk.utils.utils import COLNAMES_DF
 
 
 def fig_boxplot_msglen(df, title="", xlabel=None):
@@ -30,16 +31,16 @@ def fig_boxplot_msglen(df, title="", xlabel=None):
 
     """
     # Get message lengths
-    df['message_length'] = df['message'].apply(lambda x: len(x))
+    df[COLNAMES_DF.MESSAGE_LENGTH] = df[COLNAMES_DF.MESSAGE].apply(lambda x: len(x))
     # Sort users by median
-    user_stats = df.groupby('username')\
-        .aggregate({'message_length': 'median'})['message_length'].sort_values(ascending=False)
+    user_stats = df.groupby(COLNAMES_DF.USERNAME)\
+        .aggregate({COLNAMES_DF.MESSAGE_LENGTH: 'median'})[COLNAMES_DF.MESSAGE_LENGTH].sort_values(ascending=False)
 
     # Create a list of traces
     data = []
 
     for username in user_stats.index:
-        x = df[df['username'] == username]['message_length']
+        x = df[df[COLNAMES_DF.USERNAME] == username][COLNAMES_DF.MESSAGE_LENGTH]
         trace = go.Box(
             y=x.values,
             showlegend=True,

--- a/whatstk/utils/auto_header.py
+++ b/whatstk/utils/auto_header.py
@@ -25,12 +25,9 @@ def extract_header_from_text(text, encoding='utf-8'):
     lines = text.split('\n')
 
     # Get format auto
-    # hformat = extract_header_format_from_lines(lines)
-    # return hformat
     try:
         hformat = extract_header_format_from_lines(lines)
         logging.info("Format found was %s", hformat)
-        # print(hformat)
         return hformat
     except:  # noqa
         logging.info("Format not found.")
@@ -159,9 +156,6 @@ def _extract_header_parts(header):
         i += 1
     items = re.findall(r'[-|\]]\s[^:]*:', hformat_template)
     if len(items) != 1:
-        # print(header)
-        # print(hformat_elements)
-        # print(hformat_template)
         raise RegexError(
             "Username match was not possible. Check that header (%s) is of format '... - %name:' or '[...] %name:'",
             hformat_template)
@@ -201,7 +195,6 @@ def _extract_header_format_from_components(elements_list, template_list):
         if (len(e) == len_mode) and ("".join([str(type(ee).__name__) for ee in e]) == type_mode):
             elements_list_.append(e)
             template_list_.append(t)
-    # print(elements_list[0])
     # Get positions
     df = pd.DataFrame(elements_list_)
     dates_df = df.select_dtypes(int)

--- a/whatstk/utils/chat_generation.py
+++ b/whatstk/utils/chat_generation.py
@@ -14,6 +14,7 @@ from lorem import sentence
 from emoji.unicode_codes import EMOJI_UNICODE
 from whatstk.objects import WhatsAppChat
 from whatstk.utils.hformat import get_supported_hformats_as_list
+from whatstk.utils.utils import COLNAMES_DF
 
 
 USERS = [
@@ -112,10 +113,10 @@ class ChatGenerator:
         timestamps = self.generate_timestamps(last=last_timestamp)
         users = self.generate_users()
         df = pd.DataFrame.from_dict({
-            'date': timestamps,
-            'username': users,
-            'message': messages
-        }).set_index('date')
+            COLNAMES_DF.DATE: timestamps,
+            COLNAMES_DF.USERNAME: users,
+            COLNAMES_DF.MESSAGE: messages
+        }).set_index(COLNAMES_DF.DATE)
         return df
 
     def generate(self, filename=None, hformat=None, last_timestamp=None):

--- a/whatstk/utils/utils.py
+++ b/whatstk/utils/utils.py
@@ -1,0 +1,13 @@
+"""Utils."""
+
+
+from collections import namedtuple
+
+
+ColnamesDf = namedtuple('Constants', ['DATE', 'USERNAME', 'MESSAGE', 'MESSAGE_LENGTH'])
+COLNAMES_DF = ColnamesDf(
+    DATE='date',
+    USERNAME='username',
+    MESSAGE='message',
+    MESSAGE_LENGTH='message_length'
+)


### PR DESCRIPTION
Fixes #72 

Now, chat dataframe string columns are of type string (previously object), as pandas>=1.0.0 is being used.

**Example:**

```python
>>> from whatstk.plotly import plot, FigureBuilder
>>> from whatstk import df_from_txt
>>> filename = 'path/to/chat.txt'
>>> df = df_from_txt(filename)
>>> df.dtypes
username    string
message     string
dtype: object
```