### PR TITLE
Feature/deprecate cummulative

### DIFF
--- a/tests/analysis/test_interventions.py
+++ b/tests/analysis/test_interventions.py
@@ -211,9 +211,6 @@ def test_interventions_date_cumsum():
     assert(chat.df[COLNAMES_DF.DATE].max().date() == counts.index.max().date())
     assert(chat.df[COLNAMES_DF.DATE].min().date() == counts.index.min().date())
 
-    # TO BE DEPRECATED
-    counts = get_interventions_count(chat=chat, date_mode='date', msg_length=False, cummulative=True)
-
     assert(isinstance(counts, pd.DataFrame))
     # Asswert chat df and counts df have same users
     assert(set(chat.users) == set(counts.columns))

--- a/whatstk/analysis/interventions.py
+++ b/whatstk/analysis/interventions.py
@@ -6,8 +6,7 @@ import pandas as pd
 from whatstk.utils.utils import COLNAMES_DF, _get_df
 
 
-def get_interventions_count(df=None, chat=None, date_mode='date', msg_length=False, cumulative=False, all_users=False,
-                            cummulative=None):
+def get_interventions_count(df=None, chat=None, date_mode='date', msg_length=False, cumulative=False, all_users=False):
     """Get number of interventions per user per unit of time.
 
     The unit of time can be chosen by means of argument ``date_mode``.
@@ -29,7 +28,6 @@ def get_interventions_count(df=None, chat=None, date_mode='date', msg_length=Fal
         msg_length (bool, optional): Set to True to count the number of characters instead of number of messages sent.
         cumulative (bool, optional): Set to True to obtain commulative counts.
         all_users (bool, optional): Obtain number of interventions of all users combined. Defaults to False.
-        cummulative (bool, optional): Deprecated, use cumulative.
 
     Returns:
         pandas.DataFrame: DataFrame with shape *NxU*, where *N*: number of time-slots and *U*: number of users.
@@ -62,10 +60,6 @@ def get_interventions_count(df=None, chat=None, date_mode='date', msg_length=Fal
                 [5 rows x 8 columns]
 
     """
-    if cummulative is not None:
-        cumulative = cummulative
-        warnings.warn("cummulative is deprecated and will be removed in v0.4.0; use cumulative", DeprecationWarning)
-
     df = _get_df(df=df, chat=chat)
 
     if date_mode == 'date':

--- a/whatstk/analysis/interventions.py
+++ b/whatstk/analysis/interventions.py
@@ -1,7 +1,6 @@
 """Base analysis tools."""
 
 
-import warnings
 import pandas as pd
 from whatstk.utils.utils import COLNAMES_DF, _get_df
 

--- a/whatstk/graph/base.py
+++ b/whatstk/graph/base.py
@@ -104,7 +104,7 @@ class FigureBuilder:
         return fig
 
     def user_interventions_count_linechart(self, date_mode='date', msg_length=False, cumulative=False, all_users=False,
-                                           title="User interventions count", xlabel="Date/Time", cummulative=None):
+                                           title="User interventions count", xlabel="Date/Time"):
         """Plot number of user interventions over time.
 
         Args:
@@ -122,7 +122,6 @@ class FigureBuilder:
             all_users (bool, optional): Obtain number of interventions of all users combined. Defaults to False.
             title (str, optional): Title for plot. Defaults to "User interventions count".
             xlabel (str, optional): x-axis label title. Defaults to "Date/Time".
-            cummulative (bool, optional): Deprecated, use cumulative.
 
         Returns:
             plotly.graph_objs.Figure: Plotly Figure.
@@ -149,7 +148,6 @@ class FigureBuilder:
             msg_length=msg_length,
             cumulative=cumulative,
             all_users=all_users,
-            cummulative=cummulative
         )
         if all_users:
             fig = fig_scatter_time(


### PR DESCRIPTION
Legacy argument `cummulative` deprecated from methods `get_interventions_count`, and `user_interventions_count_linechart`