### PR TITLE
Release v0.5.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.5.0.rc1
+current_version = 0.5.0
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(.(?P<pre>[a-z]+)(?P<prenum>\d+))?
 serialize = 
 	{major}.{minor}.{patch}.{pre}{prenum}

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </h1>
 <p align="left">
   <a href="#">
-    <img alt="Package version" src="https://img.shields.io/badge/pypi-0.5.0.rc1-blue.svg?&color=25D366&logo=whatsapp&">
+    <img alt="Package version" src="https://img.shields.io/badge/pypi-0.5.0-blue.svg?&color=25D366&logo=whatsapp&">
   </a>
 </p>
 <!-- style=for-the-badge -->

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,7 +30,7 @@ copy_right = f'{datetime.now().year}, sociepy'
 author = 'lucasrodes'
 
 # The full version, including alpha/beta/rc tags
-version = 'v0.5.0.rc1'
+version = 'v0.5.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ extras_require = {
 
 setup(
     name='whatstk',
-    version="0.5.0.rc1",
+    version="0.5.0",
     description="Parser and analytics tools for WhatsApp group chats",
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/whatstk/__init__.py
+++ b/whatstk/__init__.py
@@ -12,7 +12,7 @@ from whatstk.whatsapp.parser import df_from_txt_whatsapp
 
 name = "whatstk"
 
-__version__ = "0.5.0.rc1"
+__version__ = "0.5.0"
 
 __all__ = [
     'WhatsAppChat',


### PR DESCRIPTION
## Contents
- [Enhancements](#enh)
  - [Windows support](#windows)
  - [GDrive support](#gdrive-support)
  - [Pandas friendly](#pandas)
  - [Dependencies](#dependencies)
- [Deprecated](#deprecated)
  - [Argument cumulative](#cummulative)
- [Bug fixes](#bug-fixes)
  - [Remove print statement](#print)
  - [Properly add static files to the library](#static)

# Enhancements  <a href="#enh" id="enh">#</a>

## Windows support <a href="#windows" id="windows">#</a>
_Details in #119_

CI/CD for Windows created. Passing all tests.

Previously reported errors (#102) due to encoding problems.

## GDrive support <a href="#gdrive-support" id="gdrive-support">#</a>
_Details in #117, #116_

Motivated by #113 

### Load a chat from Google Drive

You can also load a file saved in your Google Drive. Note that in order to do so, you need first to configure the
credentials to interact with Google Drive.

#### Configure credentials
In particular, you need the client secret JSON file. This can be downloaded from the Google Console. To get this file, we recommend following [this tutorial](https://medium.com/analytics-vidhya/how-to-connect-google-drive-to-python-using-pydrive-9681b2a14f20), which is
inspired by [PyDrive2 documentation](https://iterative.github.io/PyDrive2/docs/build/html/quickstart.html). Some
important  additions to previous tutorials are:

- Make sure to add yourself in Test users, as noted in [this thread](https://stackoverflow.com/questions/65980758/pydrive-quickstart-and-error-403-access-denied)
- Select Desktop App instead of Web Application as the application type when creating the OAuth Client ID.

Once you have downloaded the client secrets, run `gdrive_init`, which will
guide you through the Authentification process. You will need to access a link via your browser and copy paste a
verification code.

```python
from whatstk.utils import gdrive_init
gdrive_init("path/to/client_secrets.json")
```

This should only be run the first time to correctly configure your Google credentials.


#### Load a file from Google Drive


You can pass a file reference to `WhatsAppChat` by means of its ID. All files in Google
Drive have a unique ID. To obtain it, create a [shareable link](https://support.google.com/drive/answer/7166529?co=GENIE.Platform%3DDesktop&hl=en), which will have the following format:


```python
https://drive.google.com/file/d/[FILE-ID]/view?usp=sharing
```

Now, simply copy ``[FILE-ID]`` and run:



```python
from whatstk import WhatsAppChat
chat = WhatsAppChat.from_source("gdrive://[FILE-ID]")
```

Note that Google Drive file IDs are passed with the prefix `gdrive://`.

## Pandas friendly  <a href="#pandas" id="pandas">#</a>
_Details in #122_

Method `df_from_txt_whatsapp` is now available from root, e.g.:

```python
from whatstk import df_from_txt_whatsapp
df = df_from_txt_whatsapp("path/to/chat.txt")
```

The motivation is to make it more pandas-friendly.

## Dependencies  <a href="#dependencies" id="dependencies">#</a>
_Details in #121_

Generate and GDrive functionalities now deemed as extensions. To install dependencies for these run `pip install whatstk[gdrive]` and `pip install whatstk[generate]`, respectively. 

# Deprecated <a href="#deprecated" id="deprecated">#</a>
## `cummulative`  <a href="#cummulative" id="cummulative">#</a>
_Details in #120_

Legacy argument `cummulative` deprecated from methods `get_interventions_count`, and `user_interventions_count_linechart`

# Bug fixes  <a href="#bug-fixes" id="bug-fixes">#</a>

## Remove print statement  <a href="#print" id="print">#</a>
There was a print statement in the library.

## Properly add static files to the library  <a href="#static" id="static">#</a>
That means:
- Add `__init__.py` module to library folders containing static files.
- Add static files to MANIFEST.in