### PR TITLE
🐛 Fix unicode cleaning: NFKC normalization, preserve ZWJ/ZWNJ

### DIFF
--- a/tests/whatsapp/test_parser.py
+++ b/tests/whatsapp/test_parser.py
@@ -1,3 +1,6 @@
+from pathlib import Path
+from typing import Any
+
 from tests.paths import TEST_CHATS_HFORMATS_DIR, TEST_CHATS_MERGE_DIR, CHATS_DIR
 import pandas as pd
 import pytest
@@ -174,3 +177,86 @@ def test_message_type_non_group():
     # For non-group chats (<=2 users), all messages should be 'user'
     # Check that we have the message_type column (which covers line 150)
     assert len(df) > 0
+
+
+def _df_from_chat_content(tmp_path: Path, content: str, **kwargs: Any) -> pd.DataFrame:
+    """Write chat content to a txt file and load it with df_from_whatsapp."""
+    filepath = tmp_path / "chat.txt"
+    filepath.write_text(content, encoding="utf-8")
+    return df_from_whatsapp(str(filepath), **kwargs)
+
+
+def test_df_from_whatsapp_composed_unicode(tmp_path):
+    """Accented characters must remain composed (NFC form) after parsing.
+
+    NFKD normalization decomposed e.g. u-umlaut (U+00FC) into 'u' + combining diaeresis (U+0308), breaking downstream
+    NLP tools. See https://github.com/lucasrodes/whatstk/issues/172.
+    """
+    # 'Ju\u0308rgen': decomposed u-umlaut ('u' + combining diaeresis) in username and message
+    content = (
+        "12.06.2024, 20:35 - Ju\u0308rgen: Ich mu\u0308sste morgen fru\u0308h los\n12.06.2024, 20:36 - Hans: ok!\n"
+    )
+    df = _df_from_chat_content(tmp_path, content)
+    assert df["username"].iloc[0] == "J\u00fcrgen"
+    assert df["message"].iloc[0] == "Ich m\u00fcsste morgen fr\u00fch los"
+    # No combining marks left behind
+    assert "\u0308" not in df["message"].iloc[0]
+
+
+def test_df_from_whatsapp_zwj_emoji(tmp_path):
+    """Compound emojis (ZWJ sequences) must not be broken into their parts.
+
+    Removing the Zero Width Joiner (U+200D) turned e.g. the 'mending heart' emoji into two separate emojis. See
+    https://github.com/lucasrodes/whatstk/issues/171.
+    """
+    heart = "\u2764\ufe0f\u200d\U0001fa79"  # mending heart (ZWJ sequence)
+    family = "\U0001f468\u200d\U0001f469\u200d\U0001f466"  # family: man, woman, boy (ZWJ sequence)
+    content = (
+        f"12.06.2024, 20:35 - Ash: I feel {heart} today\n"
+        f"12.06.2024, 20:36 - Misty: nice {family}\n"
+        f"12.06.2024, 20:37 - Mom {heart}: dinner is ready\n"
+    )
+    df = _df_from_chat_content(tmp_path, content)
+    assert heart in df["message"].iloc[0]
+    assert family in df["message"].iloc[1]
+    # Username containing a ZWJ emoji must not break header detection
+    assert df["username"].iloc[2] == f"Mom {heart}"
+
+
+def test_df_from_whatsapp_zwnj_preserved(tmp_path):
+    """Zero Width Non-Joiner (U+200C) is meaningful in e.g. Persian text and must be preserved."""
+    persian = "\u0645\u06cc\u200c\u062e\u0648\u0627\u0647\u0645"  # 'I want' in Persian, contains ZWNJ
+    content = f"12.06.2024, 20:35 - Ali: {persian}\n12.06.2024, 20:36 - Sara: ok\n"
+    df = _df_from_chat_content(tmp_path, content)
+    assert df["message"].iloc[0] == persian
+
+
+def test_df_from_whatsapp_directional_marks_stripped(tmp_path):
+    """Directional marks (e.g. U+200E) inserted by WhatsApp must still be removed, so header detection works.
+
+    This was the original reason for _clean_text, see https://github.com/lucasrodes/whatstk/pull/152.
+    """
+    content = (
+        "\u200e[12.06.24, 20:35:11] Mary: hello\n"
+        "\u200e[12.06.24, 20:36:00] John: hi \u200ethere\n"
+        "\u200e[12.06.24, 20:37:00] Mary: bye\n"
+    )
+    df = _df_from_chat_content(tmp_path, content)
+    assert len(df) == 3
+    assert df["username"].tolist() == ["Mary", "John", "Mary"]
+    assert df["message"].iloc[1] == "hi there"
+
+
+def test_df_from_whatsapp_narrow_nbsp_ampm(tmp_path):
+    """Auto header detection must handle the narrow no-break space (U+202F) iOS puts before 'AM'/'PM'.
+
+    This is why _clean_text uses a compatibility normalization form (NFKC), which folds U+202F into a regular space.
+    """
+    content = (
+        "[10/31/23, 3:34:33\u202fPM] Mary: hello\n"
+        "[10/31/23, 3:35:00\u202fPM] John: hi\n"
+        "[10/31/23, 4:01:12\u202fPM] Mary: bye\n"
+    )
+    df = _df_from_chat_content(tmp_path, content)
+    assert len(df) == 3
+    assert df["date"].iloc[0].hour == 15

--- a/whatstk/whatsapp/auto_header.py
+++ b/whatstk/whatsapp/auto_header.py
@@ -107,10 +107,8 @@ def _extract_possible_header_from_line(line: str) -> str:
         # possible header
         header = line_split[0]
         if not header.isprintable():
-            print("""
-                  There is some unprintable character in the header.
-                  Please report this in https://github.com/lucasrodes/whatstk.
-            """)
+            # Not necessarily an error: e.g. usernames with compound emojis contain a Zero Width Joiner (U+200D).
+            logging.debug("Header contains unprintable characters: %r", header)
         if header[-1] != ":":
             header += ":"
         return header

--- a/whatstk/whatsapp/parser.py
+++ b/whatstk/whatsapp/parser.py
@@ -300,11 +300,13 @@ def _parse_chat(text: str, regex: str) -> pd.DataFrame:
 
 
 def _clean_text(text: str) -> str:
-    # List of additional unwanted Unicode characters
+    # List of additional unwanted Unicode characters. These are invisible formatting characters that WhatsApp inserts
+    # around headers (dates, usernames), which would otherwise break header detection and parsing.
+    # NOTE: Zero Width Joiner (U+200D) and Zero Width Non-Joiner (U+200C) must NOT be removed: ZWJ is required for
+    # compound emojis (e.g. the 'mending heart' emoji is U+2764 U+FE0F U+200D U+1FA79) and ZWNJ is meaningful in
+    # e.g. Persian text. See issue #171.
     unwanted_chars = [
         "\u200b",  # Zero Width Space
-        "\u200c",  # Zero Width Non-Joiner
-        "\u200d",  # Zero Width Joiner
         "\u202a",  # Left-to-Right Embedding
         "\u202b",  # Right-to-Left Embedding
         "\u202c",  # Pop Directional Formatting
@@ -321,7 +323,11 @@ def _clean_text(text: str) -> str:
     # Remove unwanted characters
     text = re.sub(pattern, "", text)
 
-    text = unicodedata.normalize("NFKD", text)
+    # NFKC (not NFKD, see issue #172): keeps characters composed (u-umlaut stays U+00FC instead of being decomposed
+    # into 'u' + combining diaeresis U+0308), while still folding compatibility characters. The compatibility folding
+    # (K) is required: iOS exports use a narrow no-break space (U+202F) before 'AM'/'PM', which must become a regular
+    # space for header detection to work.
+    text = unicodedata.normalize("NFKC", text)
 
     return text
 


### PR DESCRIPTION
Fixes #171
Fixes #172

## Context

`_clean_text()` was introduced in #152 because invisible Unicode formatting characters (LTR/RTL marks etc.) that WhatsApp inserts around headers were breaking automatic header detection. However, the cleaning was broader than the fix required, and caused two data-corruption issues in message content:

- **#172**: `NFKD` normalization decomposed accented characters (e.g. `ü` U+00FC → `u` + combining diaeresis U+0308), breaking downstream NLP tools such as spaCy.
- **#171**: stripping the Zero Width Joiner (U+200D) broke compound emojis (e.g. ❤️‍🩹 became ❤️🩹).

## Changes

- **Normalize with `NFKC` instead of `NFKD`**: accented characters stay composed (`ü` remains U+00FC). Compatibility folding (the "K") is deliberately kept: iOS exports use a narrow no-break space (U+202F) before "AM"/"PM", and header auto-detection relies on it being folded into a regular space. This is also why plain `NFC` is not an option.
- **Stop stripping ZWJ (U+200D) and ZWNJ (U+200C)**: ZWJ is required for compound emoji sequences; ZWNJ is linguistically meaningful (e.g. Persian). Neither is inserted by WhatsApp around headers, so header detection is unaffected. All other invisible characters (directional marks/embeddings/overrides, zero-width space, soft hyphen) are still removed — they are what #152 was actually about.
- **`auto_header.py`**: replaced the stdout `print` about unprintable header characters with `logging.debug`. Since ZWJ is now preserved, usernames containing compound emojis legitimately trip `isprintable()`, and printing a "please report this" message for every such line would be noise.

## Tests

New regression tests in `tests/whatsapp/test_parser.py` (written with explicit `\uXXXX` escapes so the invisible characters are visible in review):

- `test_df_from_whatsapp_composed_unicode` (#172): decomposed input comes out composed; fails on `develop`.
- `test_df_from_whatsapp_zwj_emoji` (#171): compound emojis survive in messages and usernames; fails on `develop`.
- `test_df_from_whatsapp_zwnj_preserved`: Persian ZWNJ preserved; fails on `develop`.
- `test_df_from_whatsapp_directional_marks_stripped`: guards the original #152 behavior (passes on `develop` too).
- `test_df_from_whatsapp_narrow_nbsp_ampm`: guards iOS U+202F am/pm auto-detection, i.e. documents why NFKC (not NFC) is needed (passes on `develop` too).

Full suite: 81 passed, coverage 95.8%. flake8 clean on changed files (the single `S105` warning in `whatstk/utils/gdrive.py` is a pre-existing bandit false positive on `develop`).

## Behavior change note

Users who relied on NFKD decomposition of the output (unlikely, given both open issues complain about it) will see composed characters from now on. Compatibility folding (fullwidth chars, `①`→`1`, etc.) behaves exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)